### PR TITLE
lib/codec/cmake: install runtime lib to correct directory

### DIFF
--- a/Source/Lib/Codec/CMakeLists.txt
+++ b/Source/Lib/Codec/CMakeLists.txt
@@ -206,4 +206,7 @@ add_dependencies(SvtHevcEnc
 
 configure_file(../pkg-config.pc.in ${CMAKE_BINARY_DIR}/SvtHevcEnc.pc @ONLY)
 install(FILES ${CMAKE_BINARY_DIR}/SvtHevcEnc.pc DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
-install(TARGETS SvtHevcEnc DESTINATION "${CMAKE_INSTALL_LIBDIR}")
+install(TARGETS SvtHevcEnc
+        LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+        ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+        RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")


### PR DESCRIPTION
On Windows, this should be the same directory as executables (RUNTIME). On non-DLL OSes it uses LIBRARY for the shared lib and ARCHIVE for the static lib.